### PR TITLE
admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ var PouchDB = require('PouchDB')
 var hapiAccount = require('hoodie-server-account')
 
 PouchDB.plugin(require('pouchdb-users'))
-PouchDB.plugin(require('pouchdb-admins'))
 
 var db = new PouchDB('http://localhost:5984/_users')
 db.useAsAuthenticationDB().then(function () {

--- a/api/README.md
+++ b/api/README.md
@@ -72,12 +72,6 @@ If you see any inconsistencies, please [create an issue](https://github.com/hood
 
 ### Constructor
 
----
-
-🐕 **TO BE DONE**: _create issue and link it here_
-
----
-
 ```js
 new AccountApi(options)
 ```
@@ -131,12 +125,6 @@ db.useAsAuthenticationDB().then(function () {
 ```
 
 ### api.sessions.add()
-
----
-
-🐕 **TO BE DONE**: [#26](https://github.com/hoodiehq/hoodie-server-account/issues/26)
-
----
 
 Admins can create a session for any user.
 
@@ -469,7 +457,7 @@ is kept, and sessions are hash based
 
 ---
 
-🐕 **TO BE DONE**: _create issue and link it here_
+🐕 **TO BE DONE**: [#27](https://github.com/hoodiehq/hoodie-server-account/issues/27)
 
 ---
 

--- a/api/README.md
+++ b/api/README.md
@@ -109,15 +109,6 @@ new AccountApi(options)
     </td>
     <td>Yes</td>
   </tr>
-  <tr>
-    <th align="left"><code>options.admins</code></th>
-    <td>Object</td>
-    <td>
-      Map of admin accounts, same format as CouchDB’s <code>admins</code>
-      configuration
-    </td>
-    <td>No</td>
-  </tr>
 </table>
 
 Returns an `api` instance.

--- a/api/README.md
+++ b/api/README.md
@@ -22,7 +22,6 @@ var AccountApi = require('hoodie-server-account/api')
 var PouchDB = require('pouchdb')
 
 PouchDB.plugin(require('pouchdb-users'))
-PouchDB.plugin(require('pouchdb-admins'))
 
 var db = new PouchDB('http://localhost:5984/_users')
 

--- a/api/README.md
+++ b/api/README.md
@@ -24,6 +24,8 @@ var PouchDB = require('pouchdb')
 PouchDB.plugin(require('pouchdb-users'))
 PouchDB.plugin(require('pouchdb-admins'))
 
+var db = new PouchDB('http://localhost:5984/_users')
+
 var api = new AccountApi({
   db: db,
   secret: 'secret123'

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -48,7 +48,19 @@ function hapiAccount (server, options, next) {
   }))
 
   async.parallel([
-    options.usersDb.put.bind(options.usersDb, usersDesignDoc),
+    putUsersDesignDoc.bind(null, options.usersDb, usersDesignDoc),
     server.register.bind(server, plugins)
   ], next)
+}
+
+function putUsersDesignDoc (db, designDoc, callback) {
+  db.put(designDoc)
+
+  .catch(function (error) {
+    if (error.name !== 'conflict') {
+      throw error
+    }
+  })
+
+  .then(callback.bind(null, null), callback)
 }

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -18,6 +18,8 @@ function hapiAccount (server, options, next) {
   var routeOptions = merge({}, options)
   routeOptions.sessionTimeout = options.sessionTimeout || TIMEOUT_14_DAYS
 
+  options.usersDb.constructor.plugin(require('pouchdb-admins'))
+
   var users = getApi({
     db: options.usersDb,
     secret: options.secret,

--- a/tests/integration/utils/get-server.js
+++ b/tests/integration/utils/get-server.js
@@ -32,7 +32,6 @@ function getServer (callback) {
     }])
 
   PouchDB.plugin(require('pouchdb-users'))
-  PouchDB.plugin(require('pouchdb-admins'))
 
   var usersDb = new PouchDB('http://localhost:5984/_users')
   usersDb.installUsersBehavior()


### PR DESCRIPTION
Do not require `pouchdb-admins` to be applied before passing instance to
hapi plugin