### PR TITLE
Issue/94 fixed

### DIFF
--- a/routes/utils/validations.js
+++ b/routes/utils/validations.js
@@ -5,7 +5,8 @@ var validations = module.exports = {}
 validations.bearerTokenHeader = Joi.object({
   authorization: Joi.string().required().regex(/^Bearer [a-zA-Z0-9_\-]+$/)
 }).unknown().required().meta({
-  statusCode: 403
+  statusCode: 401,
+  message: 'Authorization header missing'
 })
 
 validations.bearerTokenHeaderForbidden = Joi.object({

--- a/tests/integration/routes/account/patch-account-test.js
+++ b/tests/integration/routes/account/patch-account-test.js
@@ -100,7 +100,9 @@ getServer(function (error, server) {
         url: '/session/account',
         headers: {}
       }, function (response) {
-        t.is(response.statusCode, 403, 'returns 403 status')
+        t.is(response.statusCode, 401, 'returns 401 status')
+        t.is(response.result.error, 'Unauthorized', 'returns "Unauthorized" error')
+        t.is(response.result.message, 'Authorization header missing', 'returns "Authorization header missing" error')
         t.end()
       })
     })

--- a/tests/integration/routes/accounts/delete-accounts-test.js
+++ b/tests/integration/routes/accounts/delete-accounts-test.js
@@ -79,7 +79,9 @@ getServer(function (error, server) {
         url: '/accounts/abc4567',
         headers: {}
       }, function (response) {
-        t.is(response.statusCode, 403, 'returns 403 status')
+        t.is(response.statusCode, 401, 'returns 401 status')
+        t.is(response.result.error, 'Unauthorized', 'returns "Unauthorized" error')
+        t.is(response.result.message, 'Authorization header missing', 'returns "Authorization header missing" error')
         t.end()
       })
     })

--- a/tests/integration/routes/accounts/get-accounts-test.js
+++ b/tests/integration/routes/accounts/get-accounts-test.js
@@ -43,7 +43,9 @@ getServer(function (error, server) {
         url: '/accounts',
         headers: {}
       }, function (response) {
-        t.is(response.statusCode, 403, 'returns 403 status')
+        t.is(response.statusCode, 401, 'returns 401 status')
+        t.is(response.result.error, 'Unauthorized', 'returns "Unauthorized" error')
+        t.is(response.result.message, 'Authorization header missing', 'returns "Authorization header missing" error')
         t.end()
       })
     })
@@ -151,7 +153,7 @@ getServer(function (error, server) {
         url: '/accounts/abc4567',
         headers: {}
       }, function (response) {
-        t.is(response.statusCode, 403, 'returns 403 status')
+        t.is(response.statusCode, 401, 'returns 401 status')
         t.end()
       })
     })

--- a/tests/integration/routes/accounts/patch-accounts-test.js
+++ b/tests/integration/routes/accounts/patch-accounts-test.js
@@ -80,7 +80,9 @@ getServer(function (error, server) {
         url: '/accounts/abc4567',
         headers: {}
       }, function (response) {
-        t.is(response.statusCode, 403, 'returns 403 status')
+        t.is(response.statusCode, 401, 'returns 401 status')
+        t.is(response.result.error, 'Unauthorized', 'returns "Unauthorized" error')
+        t.is(response.result.message, 'Authorization header missing', 'returns "Authorization header missing" error')
         t.end()
       })
     })

--- a/tests/integration/routes/accounts/post-accounts-test.js
+++ b/tests/integration/routes/accounts/post-accounts-test.js
@@ -56,7 +56,9 @@ getServer(function (error, server) {
         url: '/accounts',
         headers: {}
       }, function (response) {
-        t.is(response.statusCode, 403, 'returns 403 status')
+        t.is(response.statusCode, 401, 'returns 401 status')
+        t.is(response.result.error, 'Unauthorized', 'returns "Unauthorized" error')
+        t.is(response.result.message, 'Authorization header missing', 'returns "Authorization header missing" error')
         t.end()
       })
     })

--- a/tests/integration/routes/session/delete-session-test.js
+++ b/tests/integration/routes/session/delete-session-test.js
@@ -35,7 +35,10 @@ test('DELETE /session', function (group) {
       delete requestOptions.headers.authorization
 
       server.inject(requestOptions, function (response) {
-        t.is(response.statusCode, 403, 'returns 403 status')
+        t.is(response.statusCode, 401, 'returns 401 status')
+        t.is(response.result.errors.length, 1, 'returns one error')
+        t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Unauthorized" error')
+        t.is(response.result.errors[0].detail, 'Authorization header missing', 'returns "Authorization header missing" error')
         t.end()
       })
     })

--- a/tests/integration/routes/session/get-session-test.js
+++ b/tests/integration/routes/session/get-session-test.js
@@ -35,13 +35,9 @@ test('GET /session', function (group) {
         url: '/session',
         headers: {}
       }, function (response) {
-        t.is(response.statusCode, 403, 'returns 403 status')
-
-        // prepared test for https://github.com/hoodiehq/hoodie-server-account/issues/94
-        // replace the line above with the 3 lines below
-        // t.is(response.statusCode, 401, 'returns 401 status')
-        // t.is(response.result.error, 'Unauthorized', 'returns "Unauthorized" error')
-        // t.is(response.result.message, 'Authorization header missing', 'returns "Authorization header missing" error')
+        t.is(response.statusCode, 401, 'returns 401 status')
+        t.is(response.result.error, 'Unauthorized', 'returns "Unauthorized" error')
+        t.is(response.result.message, 'Authorization header missing', 'returns "Authorization header missing" error')
 
         // TODO:
         // - response.result.error should be response.result.errors[0].title


### PR DESCRIPTION
The only problem is that [here](https://github.com/alisabzevari/hoodie-server-account/blob/issue/94/tests/integration/routes/session/get-session-test.js#L42) there were some TODO items which have been fixed [here](https://github.com/alisabzevari/hoodie-server-account/blob/issue/94/tests/integration/routes/session/delete-session-test.js#L39), but the TODO comment mentioned that the error message should be in `response.result.errors[0].msesage` but [here](https://github.com/alisabzevari/hoodie-server-account/blob/issue/94/tests/integration/routes/session/delete-session-test.js#L39) it was in `response.result.errors[0].detail`.

---

fixes #94