### PR TITLE
Pull Request for Issue #98

### DIFF
--- a/routes/account.js
+++ b/routes/account.js
@@ -74,7 +74,7 @@ function accountRoutes (server, options, next) {
       admins.validateSession(sessionId)
 
       .then(function (doc) {
-        throw errors.FORBIDDEN_ADMIN_ACCOUNT
+        throw errors.NO_ADMIN_ACCOUNT
       })
 
       .catch(function (error) {

--- a/routes/utils/errors.js
+++ b/routes/utils/errors.js
@@ -28,6 +28,12 @@ module.exports.FORBIDDEN_ADMIN_ACCOUNT = hoodieError({
   status: 403
 })
 
+module.exports.NO_ADMIN_ACCOUNT = hoodieError({
+  name: 'Not Found',
+  message: 'Admins have no accounts',
+  status: 404
+})
+
 function parse (error) {
   if (error.message === 'Name or password is incorrect.') {
     error.message = 'Invalid credentials'

--- a/tests/integration/routes/account/get-account-test.js
+++ b/tests/integration/routes/account/get-account-test.js
@@ -84,9 +84,9 @@ getServer(function (error, server) {
 
       server.inject(requestOptions, function (response) {
         delete response.result.meta
-        t.is(response.statusCode, 403, 'returns 403 status')
+        t.is(response.statusCode, 404, 'returns 404 status')
 
-        t.deepEqual(response.result.errors[0].detail, 'Admins have no account', 'returns "Admins have no account" error')
+        t.deepEqual(response.result.errors[0].detail, 'Admins have no accounts', 'returns "Admins have no accounts" error')
         t.end()
       })
     })


### PR DESCRIPTION
Fixed to return 404 and test modified to match, for #98 
Added an error (NO_ADMIN_ACCOUNT) to error.js which can be reused:

```js
module.exports.NO_ADMIN_ACCOUNT = hoodieError({
  name: 'Not Found',
  message: 'Admins have no accounts',
  status: 404
})
```

---

closes #98 