### PR TITLE
#100 PATCH /session/account -> 409 "data.id must be '{id}'" error

### DIFF
--- a/routes/account.js
+++ b/routes/account.js
@@ -123,6 +123,7 @@ function accountRoutes (server, options, next) {
 
       var newUsername = request.payload.data.attributes.username
       var newPassword = request.payload.data.attributes.password
+      var id = request.payload.data.id
 
       admins.validateSession(sessionId)
       .then(function (doc) {
@@ -142,6 +143,9 @@ function accountRoutes (server, options, next) {
       })
 
       .then(function (session) {
+        if (session.account.id !== id) {
+          throw errors.accountIdConflict(session.account.id)
+        }
         return accounts.update(session.account, {
           username: newUsername,
           password: newPassword

--- a/routes/utils/errors.js
+++ b/routes/utils/errors.js
@@ -40,6 +40,14 @@ module.exports.NO_PROFILE_ACCOUNT = hoodieError({
   status: 404
 })
 
+module.exports.accountIdConflict = function (id) {
+  return hoodieError({
+    name: 'Conflict',
+    message: 'data.id must be \'' + id + '\'',
+    status: 409
+  })
+}
+
 function parse (error) {
   if (error.message === 'Name or password is incorrect.') {
     error.message = 'Invalid credentials'

--- a/tests/integration/routes/account/patch-account-test.js
+++ b/tests/integration/routes/account/patch-account-test.js
@@ -108,7 +108,7 @@ getServer(function (error, server) {
     })
 
     // test prepared for https://github.com/hoodiehq/hoodie-server-account/issues/100
-    group.test('data.is is != account.id belonging to session', function (t) {
+    group.test('data.id is != account.id belonging to session', function (t) {
       var couch = mockUserFound()
       var options = _.defaultsDeep({
         payload: {
@@ -136,7 +136,6 @@ getServer(function (error, server) {
           id: 'org.couchdb.user:pat-doe',
           rev: '2-3456'
         }])
-
       server.inject(routeOptions, function (response) {
         t.is(couchdb.pendingMocks()[0], undefined, 'all mocks satisfied')
 

--- a/tests/integration/routes/account/patch-account-test.js
+++ b/tests/integration/routes/account/patch-account-test.js
@@ -108,27 +108,27 @@ getServer(function (error, server) {
     })
 
     // test prepared for https://github.com/hoodiehq/hoodie-server-account/issues/100
-    // group.test('data.is is != account.id belonging to session', function (t) {
-    //   var couch = mockUserFound()
-    //   var options = _.defaultsDeep({
-    //     payload: {
-    //       data: {
-    //         id: 'foobar'
-    //       }
-    //     }
-    //   }, routeOptions)
-    //
-    //   server.inject(options, function (response) {
-    //     t.is(couch.pendingMocks()[0], undefined, 'all mocks satisfied')
-    //
-    //     t.is(response.statusCode, 409, 'returns 409 status')
-    //     t.is(response.result.errors.length, 1, 'returns one error')
-    //     t.is(response.result.errors[0].title, 'Conflict', 'returns "Conflict" error')
-    //     t.is(response.result.errors[0].detail, 'data.id must be \'userid123\'', 'returns "data.id must be \'userid123\'" message')
-    //
-    //     t.end()
-    //   })
-    // })
+    group.test('data.is is != account.id belonging to session', function (t) {
+      var couch = mockUserFound()
+      var options = _.defaultsDeep({
+        payload: {
+          data: {
+            id: 'foobar'
+          }
+        }
+      }, routeOptions)
+
+      server.inject(options, function (response) {
+        t.is(couch.pendingMocks()[0], undefined, 'all mocks satisfied')
+
+        t.is(response.statusCode, 409, 'returns 409 status')
+        t.is(response.result.errors.length, 1, 'returns one error')
+        t.is(response.result.errors[0].title, 'Conflict', 'returns "Conflict" error')
+        t.is(response.result.errors[0].detail, 'data.id must be \'userid123\'', 'returns "data.id must be \'userid123\'" message')
+
+        t.end()
+      })
+    })
 
     group.test('changing password', function (t) {
       var couchdb = responseMock()


### PR DESCRIPTION
I couldn't find any examples of custom error messages, so I made one in the utils/errors.js file in the routes. Would this error be better handled in a different place (like in the model)? 

I couldn't figure out a way to deal with the error in the update method without screwing up the status somehow...