### PR TITLE
test(routes): PATCH /session/account/profile error for admins

### DIFF
--- a/routes/profile.js
+++ b/routes/profile.js
@@ -90,7 +90,7 @@ function profileRoutes (server, options, next) {
       admins.validateSession(sessionId)
 
         .then(function (doc) {
-          throw errors.FORBIDDEN_ADMIN_ACCOUNT
+          throw errors.NO_PROFILE_ACCOUNT
         })
 
         .catch(function (error) {

--- a/tests/integration/routes/profile/patch-profile-test.js
+++ b/tests/integration/routes/profile/patch-profile-test.js
@@ -105,9 +105,9 @@ getServer(function (error, server) {
 
       server.inject(requestOptions, function (response) {
         delete response.result.meta
-        t.is(response.statusCode, 400, 'returns 400 status')
+        t.is(response.statusCode, 404, 'returns 404 status')
         t.is(response.result.errors.length, 1, 'returns one error')
-        t.is(response.result.errors[0].title, 'Bad Request', 'returns "Bad Request" error')
+        // t.is(response.result.errors[0].title, 'Bad Request', 'returns "Bad Request" error')
         t.deepEqual(response.result.errors[0].detail, 'Admins have no account', 'returns "Admins have no account" error')
         t.end()
       })

--- a/tests/integration/routes/profile/patch-profile-test.js
+++ b/tests/integration/routes/profile/patch-profile-test.js
@@ -107,8 +107,8 @@ getServer(function (error, server) {
         delete response.result.meta
         t.is(response.statusCode, 404, 'returns 404 status')
         t.is(response.result.errors.length, 1, 'returns one error')
-        // t.is(response.result.errors[0].title, 'Bad Request', 'returns "Bad Request" error')
-        t.deepEqual(response.result.errors[0].detail, 'Admins have no account', 'returns "Admins have no account" error')
+        t.is(response.result.errors[0].title, 'Not Found', 'returns "Not Found" error')
+        t.deepEqual(response.result.errors[0].detail, 'Admins have no profiles', 'returns "Admins have no profiles" error')
         t.end()
       })
     })


### PR DESCRIPTION
Changed test to 404 and test is now failing. 
Line 110 had been added since the example linked and the "Bad Request" title did not match the requested error on this failing route. I am not sure what name might fit so I  commented out for now. 

---

fixes #103