### PR TITLE
test(routes): PATCH /session/account/profile -> 409 "data.id must be '{id}'" error

### DIFF
--- a/routes/profile.js
+++ b/routes/profile.js
@@ -85,6 +85,7 @@ function profileRoutes (server, options, next) {
     handler: function (request, reply) {
       var sessionId = toBearerToken(request)
       var givenProfile = request.payload.data.attributes
+      var id = request.payload.data.id
 
       // check for admin. If not found, check for user
       admins.validateSession(sessionId)
@@ -109,6 +110,9 @@ function profileRoutes (server, options, next) {
         })
 
         .then(function (session) {
+          if (session.account.id + '-profile' !== id) {
+            throw errors.accountIdConflict(session.account.id + '-profile')
+          }
           return accounts.update({username: session.account.username}, {
             profile: givenProfile
           }, {include: 'profile'})

--- a/tests/integration/routes/profile/patch-profile-test.js
+++ b/tests/integration/routes/profile/patch-profile-test.js
@@ -114,27 +114,27 @@ getServer(function (error, server) {
     })
 
     // test prepared for https://github.com/hoodiehq/hoodie-server-account/issues/104
-    // group.test('data.is is != account.id belonging to session', function (t) {
-    //   var couch = mockUserFound()
-    //   var options = _.defaultsDeep({
-    //     payload: {
-    //       data: {
-    //         id: 'foobar-profile'
-    //       }
-    //     }
-    //   }, routeOptions)
-    //
-    //   server.inject(options, function (response) {
-    //     t.is(couch.pendingMocks()[0], undefined, 'all mocks satisfied')
-    //
-    //     t.is(response.statusCode, 409, 'returns 409 status')
-    //     t.is(response.result.errors.length, 1, 'returns one error')
-    //     t.is(response.result.errors[0].title, 'Conflict', 'returns "Conflict" error')
-    //     t.is(response.result.errors[0].detail, 'data.id must be \'userid123-profile\'', 'returns "data.id must be \'userid123-profile\'" message')
-    //
-    //     t.end()
-    //   })
-    // })
+    group.test('data.id is != account.id belonging to session', function (t) {
+      var couch = mockUserFound()
+      var options = _.defaultsDeep({
+        payload: {
+          data: {
+            id: 'foobar-profile'
+          }
+        }
+      }, routeOptions)
+
+      server.inject(options, function (response) {
+        t.is(couch.pendingMocks()[0], undefined, 'all mocks satisfied')
+
+        t.is(response.statusCode, 409, 'returns 409 status')
+        t.is(response.result.errors.length, 1, 'returns one error')
+        t.is(response.result.errors[0].title, 'Conflict', 'returns "Conflict" error')
+        t.is(response.result.errors[0].detail, 'data.id must be \'userid123-profile\'', 'returns "data.id must be \'userid123-profile\'" message')
+
+        t.end()
+      })
+    })
 
     group.end()
   })


### PR DESCRIPTION
fixes #104